### PR TITLE
feat: getter for device serial property

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,6 +220,9 @@ pub struct Device<'m> {
 	pub name: String,
 }
 impl Device<'_> {
+	pub fn serial(&self) -> Result<String, MndResult> {
+		self.get_info_string(MndProperty::PropertySerialString)
+	}
 	pub fn get_info_bool(&self, property: MndProperty) -> Result<bool, MndResult> {
 		let mut value: bool = Default::default();
 		unsafe {

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -44,7 +44,6 @@ pub enum MndProperty {
 	PropertySerialString = 2,
 }
 
-
 #[doc = " Opaque type for libmonado state"]
 pub type MndRootPtr = *mut c_void;
 


### PR DESCRIPTION
Another problem is that the various property getters are unusable as `MndProperty` isn't public and therefore unusable from outside of this library