### PR TITLE
galister wrecks code quality

### DIFF
--- a/examples/dump_info.rs
+++ b/examples/dump_info.rs
@@ -22,7 +22,7 @@ fn main() {
 		println!();
 	}
 	for device in monado.devices().unwrap() {
-		let _ = dbg!(device.id, device.serial());
+		let _ = dbg!(device.name_id, device.serial());
 		println!();
 	}
 	for tracking_origin in monado.tracking_origins().unwrap() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ use std::ffi::OsStr;
 use std::fmt::Debug;
 use std::fs;
 use std::path::PathBuf;
+use std::ptr;
 use std::vec;
 use sys::MndRootPtr;
 use sys::MonadoApi;
@@ -387,7 +388,8 @@ impl Device<'_> {
 		Ok(value)
 	}
 	pub fn get_info_string(&self, property: MndProperty) -> Result<String, MndResult> {
-		let value = CString::default();
+		let mut cstr_ptr = ptr::null_mut();
+
 		unsafe {
 			self.monado
 				.api
@@ -395,11 +397,12 @@ impl Device<'_> {
 					self.monado.root,
 					self.index,
 					property,
-					value.as_ptr(),
+					&mut cstr_ptr,
 				)
 				.to_result()?
 		}
-		Ok(value.to_string_lossy().to_string())
+
+		unsafe { Ok(CStr::from_ptr(cstr_ptr).to_string_lossy().to_string()) }
 	}
 }
 impl Debug for Device<'_> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 mod space;
 mod sys;
 
+pub use semver::Version;
 pub use space::*;
 pub use sys::ClientState;
 pub use sys::MndProperty;
@@ -8,7 +9,7 @@ pub use sys::MndResult;
 
 use dlopen2::wrapper::Container;
 use flagset::FlagSet;
-use semver::{Version, VersionReq};
+use semver::VersionReq;
 use serde::Deserialize;
 use std::env;
 use std::ffi::c_char;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,9 @@ mod space;
 mod sys;
 
 pub use space::*;
+pub use sys::ClientState;
+pub use sys::MndProperty;
+pub use sys::MndResult;
 
 use dlopen2::wrapper::Container;
 use flagset::FlagSet;
@@ -16,9 +19,6 @@ use std::fmt::Debug;
 use std::fs;
 use std::path::PathBuf;
 use std::vec;
-use sys::ClientState;
-use sys::MndProperty;
-use sys::MndResult;
 use sys::MndRootPtr;
 use sys::MonadoApi;
 

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -1,7 +1,7 @@
 use dlopen2::wrapper::WrapperApi;
-use std::ffi::c_void;
 use std::fmt::Debug;
 use std::os::raw::c_char;
+use std::{ffi::c_void, fmt::Display};
 
 use crate::space::{MndPose, ReferenceSpaceType};
 
@@ -25,6 +25,24 @@ impl MndResult {
 		} else {
 			Err(self)
 		}
+	}
+}
+
+impl std::error::Error for MndResult {
+	fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+		None
+	}
+	fn cause(&self) -> Option<&dyn std::error::Error> {
+		None
+	}
+	fn description(&self) -> &str {
+		"std::error::Error::description() is deprecated, use the Display impl instead."
+	}
+}
+
+impl Display for MndResult {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		write!(f, "{:?}", self)
 	}
 }
 

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -117,7 +117,7 @@ pub struct MonadoApi {
 		root: MndRootPtr,
 		device_index: u32,
 		mnd_property_t: MndProperty,
-		out_string: *const ::std::os::raw::c_char,
+		out_string: *mut *mut ::std::os::raw::c_char,
 	) -> MndResult,
 
 	mnd_root_get_reference_space_offset: unsafe extern "C" fn(

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -64,6 +64,9 @@ flagset::flags! {
 pub enum MndProperty {
 	PropertyNameString = 0,
 	PropertySerialString = 1,
+	PropertyTrackingOriginU32 = 2,
+	PropertySupportsPositionBool = 3,
+	PropertySupportsOrientationBool = 4,
 }
 
 #[doc = " Opaque type for libmonado state"]


### PR DESCRIPTION
changes:
- re-exporting some missing types that are either arg or return types of the public-facing API
- renamed `id` to `name_id` on device, as `id` hints being a unique identifier, while in reality it's a numeric representation of the device name (make+model)
- impl std Error for MndResult so that you can easily use it with `?`
- fix string properties always returning empty string
- add new properties for [libmonado 1.4.0](https://gitlab.freedesktop.org/monado/monado/-/merge_requests/2313/)