### PR TITLE
Fix Missing Rename to libmonado

### DIFF
--- a/examples/dump_info.rs
+++ b/examples/dump_info.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use libmonado_rs::Monado;
+use libmonado::Monado;
 use std::path::PathBuf;
 
 #[derive(Parser)]


### PR DESCRIPTION
- Update dump_info.rs to use new library name