### PR TITLE
fix: look up libmonado relative to the canonical json file location

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,8 +112,14 @@ impl Monado {
 			});
 
 		let Some((runtime_json, mut runtime_path)) = override_runtime else {
-			return Err("Couldn't find the actively running runtime".to_string());
+			return Err("Couldn't find the active runtime json".to_string());
 		};
+
+		// Resolve libmonado relative to the real file, not the symlink.
+		runtime_path = std::fs::canonicalize(runtime_path).map_err(|err| {
+			format!("Failed to canonicalize runtime json path: {}", err.kind())
+		})?;
+
 		runtime_path.pop();
 		let Some(libmonado_path) = runtime_json.runtime.libmonado_path else {
 			return Err("Couldn't find libmonado path in active runtime json".to_string());


### PR DESCRIPTION
Test case:

`/usr/share/openxr/1/openxr_monado.json`:
```json
{
    "file_format_version": "1.0.0",
    "runtime": {
        "name": "Monado",
        "library_path": "../../../lib/libopenxr_monado.so",
        "MND_libmonado_path": "../../../lib/libmonado.so"
    }
}
```

```
$ mkdir -p /etc/xdg/openxr/1
$ ln -s /usr/share/openxr/1/openxr_monado.json /etc/xdg/openxr/1/active_runtime.json
```

With the current behavior, it attempts to resolve libmonado from `/etc/lib/libmonado.so`.

This change mirrors the behavior of OpenXR-SDK:
https://github.com/KhronosGroup/OpenXR-SDK-Source/blob/b15ef6ce120dad1c7d3ff57039e73ba1a9f17102/src/loader/manifest_file.cpp#L626C18-L626C46