### PR TITLE
refactor: per method version detection

### DIFF
--- a/examples/dump_info.rs
+++ b/examples/dump_info.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use libmonado::{Monado, ClientLogic, DeviceLogic};
+use libmonado::{ClientLogic, DeviceLogic, Monado};
 use std::path::PathBuf;
 
 #[derive(Parser)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@ pub use sys::MndResult;
 
 use dlopen2::wrapper::Container;
 use flagset::FlagSet;
-use semver::VersionReq;
 use serde::Deserialize;
 use std::env;
 use std::ffi::*;
@@ -19,13 +18,14 @@ use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
 use std::ptr;
+use std::sync::LazyLock;
 use std::vec;
 use sys::MndRootPtr;
 use sys::MonadoApi;
 
-fn crate_api_version() -> VersionReq {
-	VersionReq::parse("^1.3.0").unwrap()
-}
+pub static CRATE_VERSION: LazyLock<Version> =
+	LazyLock::new(|| Version::parse(env!("CARGO_PKG_VERSION")).unwrap());
+
 fn get_api_version(api: &Container<MonadoApi>) -> Version {
 	let mut major = 0;
 	let mut minor = 0;
@@ -171,6 +171,7 @@ struct DeviceData {
 pub struct Monado {
 	api: Container<MonadoApi>,
 	root: MndRootPtr,
+	version: Version,
 }
 impl Monado {
 	pub fn auto_connect() -> Result<Self, String> {
@@ -214,23 +215,22 @@ impl Monado {
 	pub fn create<S: AsRef<OsStr>>(libmonado_so: S) -> Result<Self, MndResult> {
 		let api = unsafe { Container::<MonadoApi>::load(libmonado_so) }
 			.map_err(|_| MndResult::ErrorConnectingFailed)?;
-		if !crate_api_version().matches(&get_api_version(&api)) {
-			return Err(MndResult::ErrorInvalidVersion);
-		}
+		let version = get_api_version(&api);
 		let mut root = std::ptr::null_mut();
 		unsafe {
 			api.mnd_root_create(&mut root).to_result()?;
 		}
-		Ok(Monado { api, root })
+		Ok(Monado { api, root, version })
 	}
 
 	pub fn get_api_version(&self) -> Version {
-		get_api_version(&self.api)
+		self.version.clone()
 	}
 	pub fn recenter_local_spaces(&self) -> Result<(), MndResult> {
 		unsafe {
 			self.api
 				.mnd_root_recenter_local_spaces(self.root)
+				.ok_or(MndResult::ErrorInvalidVersion)?
 				.to_result()
 		}
 	}
@@ -260,32 +260,32 @@ impl Monado {
 		Ok(clients.into_iter().flatten())
 	}
 
-	pub fn clients(&self) -> Result<impl IntoIterator<Item = Client>, MndResult> {
-		self.client_ids().map(|res| {
-			res.into_iter().map(|id| Client {
-				id,
-				monado: self,
-			})
-		})
+	pub fn clients<'m>(&'m self) -> Result<impl IntoIterator<Item = Client<'m>>, MndResult> {
+		self.client_ids()
+			.map(|res| res.into_iter().map(|id| Client { id, monado: self }))
 	}
 
-    #[cfg(feature = "arc")]
+	#[cfg(feature = "arc")]
 	pub fn clients_arc(this: &std::sync::Arc<Self>) -> Result<Vec<ClientArc>, MndResult> {
 		this.client_ids().map(|res| {
-			res.into_iter().map(|id| ClientArc {
-				id,
-				monado: this.clone(),
-			}).collect()
+			res.into_iter()
+				.map(|id| ClientArc {
+					id,
+					monado: this.clone(),
+				})
+				.collect()
 		})
 	}
 
-    #[cfg(feature = "rc")]
+	#[cfg(feature = "rc")]
 	pub fn clients_rc(this: &std::rc::Rc<Self>) -> Result<Vec<ClientRc>, MndResult> {
 		this.client_ids().map(|res| {
-			res.into_iter().map(|id| ClientRc {
-				id,
-				monado: this.clone(),
-			}).collect()
+			res.into_iter()
+				.map(|id| ClientRc {
+					id,
+					monado: this.clone(),
+				})
+				.collect()
 		})
 	}
 
@@ -384,7 +384,7 @@ impl Monado {
 		})
 	}
 
-    #[cfg(feature = "arc")]
+	#[cfg(feature = "arc")]
 	pub fn devices_arc(this: &std::sync::Arc<Self>) -> Result<Vec<DeviceArc>, MndResult> {
 		let data = this.devices_data();
 		data.map(|res| {
@@ -399,7 +399,7 @@ impl Monado {
 		})
 	}
 
-    #[cfg(feature = "rc")]
+	#[cfg(feature = "rc")]
 	pub fn devices_rc(this: &std::rc::Rc<Self>) -> Result<Vec<DeviceRc>, MndResult> {
 		let data = this.devices_data();
 		data.map(|res| {
@@ -491,7 +491,7 @@ pub trait ClientLogic: MonadoRef {
 			monado
 				.api
 				.mnd_root_set_client_io_blocks(monado.root, self.id(), block_flags.bits())
-				.ok_or(MndResult::ErrorUnsupportedOperation)?
+				.ok_or(MndResult::ErrorInvalidVersion)?
 				.to_result()?;
 		}
 		Ok(())
@@ -569,6 +569,7 @@ pub trait DeviceLogic: MonadoRef {
 					&mut charging,
 					&mut charge,
 				)
+				.ok_or(MndResult::ErrorInvalidVersion)?
 				.to_result()?;
 		}
 		Ok(BatteryStatus {
@@ -587,6 +588,7 @@ pub trait DeviceLogic: MonadoRef {
 			monado
 				.api
 				.mnd_root_get_device_info_bool(monado.root, self.index(), property, &mut value)
+				.ok_or(MndResult::ErrorInvalidVersion)?
 				.to_result()?
 		}
 		Ok(value)
@@ -598,6 +600,7 @@ pub trait DeviceLogic: MonadoRef {
 			monado
 				.api
 				.mnd_root_get_device_info_u32(monado.root, self.index(), property, &mut value)
+				.ok_or(MndResult::ErrorInvalidVersion)?
 				.to_result()?
 		}
 		Ok(value)
@@ -609,6 +612,7 @@ pub trait DeviceLogic: MonadoRef {
 			monado
 				.api
 				.mnd_root_get_device_info_i32(monado.root, self.index(), property, &mut value)
+				.ok_or(MndResult::ErrorInvalidVersion)?
 				.to_result()?
 		}
 		Ok(value)
@@ -620,6 +624,7 @@ pub trait DeviceLogic: MonadoRef {
 			monado
 				.api
 				.mnd_root_get_device_info_float(monado.root, self.index(), property, &mut value)
+				.ok_or(MndResult::ErrorInvalidVersion)?
 				.to_result()?
 		}
 		Ok(value)
@@ -632,6 +637,7 @@ pub trait DeviceLogic: MonadoRef {
 			monado
 				.api
 				.mnd_root_get_device_info_string(monado.root, self.index(), property, &mut cstr_ptr)
+				.ok_or(MndResult::ErrorInvalidVersion)?
 				.to_result()?
 		}
 
@@ -644,6 +650,7 @@ pub trait DeviceLogic: MonadoRef {
 			monado
 				.api
 				.mnd_root_get_device_brightness(monado.root, self.index(), &mut brightness)
+				.ok_or(MndResult::ErrorInvalidVersion)?
 				.to_result()?;
 		}
 		Ok(brightness)
@@ -654,6 +661,7 @@ pub trait DeviceLogic: MonadoRef {
 			monado
 				.api
 				.mnd_root_set_device_brightness(monado.root, self.index(), brightness, relative)
+				.ok_or(MndResult::ErrorInvalidVersion)?
 				.to_result()
 		}
 	}

--- a/src/space.rs
+++ b/src/space.rs
@@ -107,6 +107,7 @@ impl Monado {
 		unsafe {
 			self.api
 				.mnd_root_get_tracking_origin_count(self.root, &mut count)
+				.ok_or(MndResult::ErrorInvalidVersion)?
 				.to_result()?
 		};
 		let mut tracking_origins: Vec<Option<TrackingOrigin>> =
@@ -116,6 +117,7 @@ impl Monado {
 			unsafe {
 				self.api
 					.mnd_root_get_tracking_origin_name(self.root, id as u32, &mut c_name)
+					.ok_or(MndResult::ErrorInvalidVersion)?
 					.to_result()?
 			};
 			let name = unsafe {
@@ -141,6 +143,7 @@ impl Monado {
 		unsafe {
 			self.api
 				.mnd_root_get_reference_space_offset(self.root, space_type, &mut mnd_pose)
+				.ok_or(MndResult::ErrorInvalidVersion)?
 				.to_result()?;
 		}
 		Ok(mnd_pose.into())
@@ -153,6 +156,7 @@ impl Monado {
 		unsafe {
 			self.api
 				.mnd_root_set_reference_space_offset(self.root, space_type, &pose.into())
+				.ok_or(MndResult::ErrorInvalidVersion)?
 				.to_result()
 		}
 	}
@@ -171,6 +175,7 @@ impl TrackingOrigin<'_> {
 			self.monado
 				.api
 				.mnd_root_get_tracking_origin_offset(self.monado.root, self.id, &mut mnd_pose)
+				.ok_or(MndResult::ErrorInvalidVersion)?
 				.to_result()?;
 		}
 		Ok(mnd_pose.into())
@@ -180,6 +185,7 @@ impl TrackingOrigin<'_> {
 			self.monado
 				.api
 				.mnd_root_set_tracking_origin_offset(self.monado.root, self.id, &pose.into())
+				.ok_or(MndResult::ErrorInvalidVersion)?
 				.to_result()
 		}
 	}

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -93,116 +93,193 @@ pub type MndRootPtr = *mut c_void;
 
 #[derive(WrapperApi)]
 pub struct MonadoApi {
+	// === API version 1.0 ===
+
+	/// Get the API version (not Monado itself).
 	mnd_api_get_version:
 		unsafe extern "C" fn(out_major: *mut u32, out_minor: *mut u32, out_patch: *mut u32),
+	/// Create libmonado state and connect to service.
 	mnd_root_create: unsafe extern "C" fn(out_root: *mut MndRootPtr) -> MndResult,
+	/// Destroy libmonado state, disconnecting from the service.
 	mnd_root_destroy: unsafe extern "C" fn(out_root: *mut MndRootPtr),
+	/// Update the local cached copy of the client list.
 	mnd_root_update_client_list: unsafe extern "C" fn(root: MndRootPtr) -> MndResult,
+	/// Get the number of active clients.
 	mnd_root_get_number_clients:
 		unsafe extern "C" fn(root: MndRootPtr, out_num: *mut u32) -> MndResult,
+	/// Get the id from the current client list at the given index.
 	mnd_root_get_client_id_at_index:
 		unsafe extern "C" fn(root: MndRootPtr, index: u32, out_client_id: *mut u32) -> MndResult,
+	/// Get the name of the client with the given id.
 	mnd_root_get_client_name: unsafe extern "C" fn(
 		root: MndRootPtr,
 		client_id: u32,
 		out_name: *mut *const ::std::os::raw::c_char,
 	) -> MndResult,
+	/// Get the state flags of the client with the given id.
 	mnd_root_get_client_state:
 		unsafe extern "C" fn(root: MndRootPtr, client_id: u32, out_flags: *mut u32) -> MndResult,
+	/// Set the client with the given id as "primary".
 	mnd_root_set_client_primary:
 		unsafe extern "C" fn(root: MndRootPtr, client_id: u32) -> MndResult,
+	/// Set the client with the given id as "focused".
 	mnd_root_set_client_focused:
 		unsafe extern "C" fn(root: MndRootPtr, client_id: u32) -> MndResult,
+	/// Toggle IO activity for a client. Deprecated in version 1.6.
 	mnd_root_toggle_client_io_active:
 		unsafe extern "C" fn(root: MndRootPtr, client_id: u32) -> MndResult,
-	mnd_root_set_client_io_blocks: Option<
-		unsafe extern "C" fn(root: MndRootPtr, client_id: u32, block_flags: u32) -> MndResult,
-	>,
+	/// Get the number of devices.
 	mnd_root_get_device_count:
 		unsafe extern "C" fn(root: MndRootPtr, out_device_count: *mut u32) -> MndResult,
+	/// Get device info at the given index. Deprecated in version 1.2.
 	mnd_root_get_device_info: unsafe extern "C" fn(
 		root: MndRootPtr,
 		device_index: u32,
 		out_index: *mut u32,
 		out_dev_name: *mut *const ::std::os::raw::c_char,
 	) -> MndResult,
+	/// Get the device index associated with a given role name.
 	mnd_root_get_device_from_role: unsafe extern "C" fn(
 		root: MndRootPtr,
 		role_name: *const ::std::os::raw::c_char,
 		out_index: *mut i32,
 	) -> MndResult,
-	mnd_root_recenter_local_spaces: unsafe extern "C" fn(root: MndRootPtr) -> MndResult,
-	mnd_root_get_device_info_bool: unsafe extern "C" fn(
-		root: MndRootPtr,
-		device_index: u32,
-		mnd_property_t: MndProperty,
-		out_bool: *mut bool,
-	) -> MndResult,
-	mnd_root_get_device_info_i32: unsafe extern "C" fn(
-		root: MndRootPtr,
-		device_index: u32,
-		mnd_property_t: MndProperty,
-		out_i32: *mut i32,
-	) -> MndResult,
-	mnd_root_get_device_info_u32: unsafe extern "C" fn(
-		root: MndRootPtr,
-		device_index: u32,
-		mnd_property_t: MndProperty,
-		out_u32: *mut u32,
-	) -> MndResult,
-	mnd_root_get_device_info_float: unsafe extern "C" fn(
-		root: MndRootPtr,
-		device_index: u32,
-		mnd_property_t: MndProperty,
-		out_float: *mut f32,
-	) -> MndResult,
-	mnd_root_get_device_info_string: unsafe extern "C" fn(
-		root: MndRootPtr,
-		device_index: u32,
-		mnd_property_t: MndProperty,
-		out_string: *mut *mut ::std::os::raw::c_char,
-	) -> MndResult,
 
-	mnd_root_get_reference_space_offset: unsafe extern "C" fn(
-		root: MndRootPtr,
-		type_: ReferenceSpaceType,
-		out_offset: *mut MndPose,
-	) -> MndResult,
-	mnd_root_set_reference_space_offset: unsafe extern "C" fn(
-		root: MndRootPtr,
-		type_: ReferenceSpaceType,
-		offset: *const MndPose,
-	) -> MndResult,
-	mnd_root_get_tracking_origin_offset: unsafe extern "C" fn(
-		root: MndRootPtr,
-		origin_id: u32,
-		out_offset: *mut MndPose,
-	) -> MndResult,
-	mnd_root_set_tracking_origin_offset:
+	// === API version 1.1 ===
+
+	/// Trigger a recenter of the local spaces. Since API version 1.1.
+	mnd_root_recenter_local_spaces: Option<
+		unsafe extern "C" fn(root: MndRootPtr) -> MndResult,
+	>,
+
+	// === API version 1.2 ===
+
+	/// Get boolean property for a device. Since API version 1.2.
+	mnd_root_get_device_info_bool: Option<
+		unsafe extern "C" fn(
+			root: MndRootPtr,
+			device_index: u32,
+			mnd_property_t: MndProperty,
+			out_bool: *mut bool,
+		) -> MndResult,
+	>,
+	/// Get i32 property for a device. Since API version 1.2.
+	mnd_root_get_device_info_i32: Option<
+		unsafe extern "C" fn(
+			root: MndRootPtr,
+			device_index: u32,
+			mnd_property_t: MndProperty,
+			out_i32: *mut i32,
+		) -> MndResult,
+	>,
+	/// Get u32 property for a device. Since API version 1.2.
+	mnd_root_get_device_info_u32: Option<
+		unsafe extern "C" fn(
+			root: MndRootPtr,
+			device_index: u32,
+			mnd_property_t: MndProperty,
+			out_u32: *mut u32,
+		) -> MndResult,
+	>,
+	/// Get float property for a device. Since API version 1.2.
+	mnd_root_get_device_info_float: Option<
+		unsafe extern "C" fn(
+			root: MndRootPtr,
+			device_index: u32,
+			mnd_property_t: MndProperty,
+			out_float: *mut f32,
+		) -> MndResult,
+	>,
+	/// Get string property for a device. Since API version 1.2.
+	mnd_root_get_device_info_string: Option<
+		unsafe extern "C" fn(
+			root: MndRootPtr,
+			device_index: u32,
+			mnd_property_t: MndProperty,
+			out_string: *mut *mut ::std::os::raw::c_char,
+		) -> MndResult,
+	>,
+
+	// === API version 1.3 ===
+
+	/// Get the current offset of a reference space. Since API version 1.3.
+	mnd_root_get_reference_space_offset: Option<
+		unsafe extern "C" fn(
+			root: MndRootPtr,
+			type_: ReferenceSpaceType,
+			out_offset: *mut MndPose,
+		) -> MndResult,
+	>,
+	/// Apply an offset to a reference space. Since API version 1.3.
+	mnd_root_set_reference_space_offset: Option<
+		unsafe extern "C" fn(
+			root: MndRootPtr,
+			type_: ReferenceSpaceType,
+			offset: *const MndPose,
+		) -> MndResult,
+	>,
+	/// Read the current offset of a tracking origin. Since API version 1.3.
+	mnd_root_get_tracking_origin_offset: Option<
+		unsafe extern "C" fn(
+			root: MndRootPtr,
+			origin_id: u32,
+			out_offset: *mut MndPose,
+		) -> MndResult,
+	>,
+	/// Apply an offset to a tracking origin. Since API version 1.3.
+	mnd_root_set_tracking_origin_offset: Option<
 		unsafe extern "C" fn(root: MndRootPtr, origin_id: u32, offset: *const MndPose) -> MndResult,
-	mnd_root_get_tracking_origin_count:
+	>,
+	/// Get the number of tracking origins. Since API version 1.3.
+	mnd_root_get_tracking_origin_count: Option<
 		unsafe extern "C" fn(root: MndRootPtr, out_track_count: *mut u32) -> MndResult,
-	mnd_root_get_tracking_origin_name: unsafe extern "C" fn(
-		root: MndRootPtr,
-		origin_id: u32,
-		out_string: *mut *const c_char,
-	) -> MndResult,
-	mnd_root_get_device_battery_status: unsafe extern "C" fn(
-		root: MndRootPtr,
-		device_index: u32,
-		out_present: *mut bool,
-		out_charging: *mut bool,
-		out_charge: *mut f32,
-	) -> MndResult,
-	mnd_root_get_device_brightness: unsafe extern "C" fn(
-		root: MndRootPtr,
-		device_index: u32,
-		out_brightness: *mut f32,
-	) -> MndResult,
-	mnd_root_set_device_brightness: unsafe extern "C" fn(
-		root: MndRootPtr,
-		device_index: u32,
-		brightness: f32,
-		relative: bool,
-	) -> MndResult,
+	>,
+	/// Get the name of a tracking origin. Since API version 1.3.
+	mnd_root_get_tracking_origin_name: Option<
+		unsafe extern "C" fn(
+			root: MndRootPtr,
+			origin_id: u32,
+			out_string: *mut *const c_char,
+		) -> MndResult,
+	>,
+
+	// === API version 1.4 ===
+
+	/// Get battery status of a device. Since API version 1.4.
+	mnd_root_get_device_battery_status: Option<
+		unsafe extern "C" fn(
+			root: MndRootPtr,
+			device_index: u32,
+			out_present: *mut bool,
+			out_charging: *mut bool,
+			out_charge: *mut f32,
+		) -> MndResult,
+	>,
+
+	// === API version 1.5 ===
+
+	/// Get current brightness of a display device. Since API version 1.5.
+	mnd_root_get_device_brightness: Option<
+		unsafe extern "C" fn(
+			root: MndRootPtr,
+			device_index: u32,
+			out_brightness: *mut f32,
+		) -> MndResult,
+	>,
+	/// Set the display brightness. Since API version 1.5.
+	mnd_root_set_device_brightness: Option<
+		unsafe extern "C" fn(
+			root: MndRootPtr,
+			device_index: u32,
+			brightness: f32,
+			relative: bool,
+		) -> MndResult,
+	>,
+
+	// === API version 1.6 ===
+
+	/// Block certain types of IO for a client. Since API version 1.6.
+	mnd_root_set_client_io_blocks: Option<
+		unsafe extern "C" fn(root: MndRootPtr, client_id: u32, block_flags: u32) -> MndResult,
+	>,
 }


### PR DESCRIPTION
@ImSapphire @GabMus @galister 

hey so am considering doing this instead of erroring on device creation, this should allow for the crate to be backwards compatible and every method not in 1.0 that it can't find in the libmonado binary will simply error `MndResult::ErrorInvalidVersion`

any objections? you're all users of this crate for your projects